### PR TITLE
Adds new Sign up form 

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,6 +7,9 @@
     <li class="nav-item">
       <a class="nav-link" href="gallery.html">Gallery</a>
     </li>
+    <li class="nav-item">
+      <a class="nav-link" href="/">Sign up form</a>
+    </li>
   </ul>
 </nav>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
       <a class="nav-link" href="gallery.html">Gallery</a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" href="/">Sign up form</a>
+      <a class="nav-link" href="sign_up_form.html">Sign up form</a>
     </li>
   </ul>
 </nav>

--- a/_layouts/sign_up_form.html
+++ b/_layouts/sign_up_form.html
@@ -13,19 +13,6 @@
   <button type="submit">Send</button>
 </form>
 
-{% comment %}
-<form accept-charset="UTF-8" action="https://docs.google.com/forms/d/e/1FAIpQLSftbQrHueHZpjbXyXhWKvR-uixs2J_BFhxJL29ZVp-v9vFoiQ/viewform" method="POST">
-  <input type="email" name="email" placeholder="Your Email">
-  <input type="text" name="name" placeholder="Your Name">
-  <input type="hidden" name="utf8" value="✓">
-  <button type="submit">Submit</button>
-</form>
-{% endcomment %}
-
-{% comment %}
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSftbQrHueHZpjbXyXhWKvR-uixs2J_BFhxJL29ZVp-v9vFoiQ/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
-{% endcomment %}
-
 </div>
 {% include footer.html %}
 

--- a/_layouts/sign_up_form.html
+++ b/_layouts/sign_up_form.html
@@ -5,7 +5,7 @@
 
 <h1>Hack Brexit Mailing List</h1>
 
-<p>Sign up on our Hack Brexit contact form for us to keep you updated with all of the latest news </p>
+<p>Fill in your details below for us to keep you updated with the latest news and developments about the Hack Brexit project.</p>
 
 <form method="POST" action="http://formspree.io/hackbrexit@gmail.com">
 
@@ -22,12 +22,6 @@
  <button type="submit" class="btn btn-primary">Sign up for updates on Hack Brexit</button>
 </form>
 
-{% comment %}
-  <input type="email" name="email" placeholder="Your email">
-  <input type="name" name="name" placeholder="Your name">
-  <button type="submit">Send</button>
-</form>
-{% endcomment %}
 
 </div>
 {% include footer.html %}

--- a/_layouts/sign_up_form.html
+++ b/_layouts/sign_up_form.html
@@ -8,10 +8,26 @@
 <p>Sign up on our Hack Brexit contact form for us to keep you updated with all of the latest news </p>
 
 <form method="POST" action="http://formspree.io/hackbrexit@gmail.com">
+
+<form class="form-inline">
+  <div class="form-group">
+       <label for="exampleInputName2">Name</label>
+       <input type="name" name="name" class="form-control" id="exampleInputName2" placeholder="Your name">
+
+ </div>
+ <div class="form-group">
+   <label for="exampleInputEmail2">Email</label>
+   <input type="email" email="email" class="form-control" id="exampleInputEmail2" placeholder="Your email">
+ </div>
+ <button type="submit" class="btn btn-primary">Sign up for updates on Hack Brexit</button>
+</form>
+
+{% comment %}
   <input type="email" name="email" placeholder="Your email">
   <input type="name" name="name" placeholder="Your name">
   <button type="submit">Send</button>
 </form>
+{% endcomment %}
 
 </div>
 {% include footer.html %}

--- a/_layouts/sign_up_form.html
+++ b/_layouts/sign_up_form.html
@@ -7,9 +7,17 @@
 
 <p>Sign up on our Hack Brexit contact form for us to keep you updated with all of the latest news </p>
 
-  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSftbQrHueHZpjbXyXhWKvR-uixs2J_BFhxJL29ZVp-v9vFoiQ/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+<form accept-charset="UTF-8" action="https://docs.google.com/forms/d/e/1FAIpQLSftbQrHueHZpjbXyXhWKvR-uixs2J_BFhxJL29ZVp-v9vFoiQ/viewform" method="POST">
+  <input type="email" name="email" placeholder="Your Email">
+  <input type="text" name="name" placeholder="Your Name">
+  <input type="hidden" name="utf8" value="✓">
+  <button type="submit">Submit</button>
+</form>
 
-    {% endfor %}
+{% comment %}
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSftbQrHueHZpjbXyXhWKvR-uixs2J_BFhxJL29ZVp-v9vFoiQ/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+{% endcomment %}
+
 </div>
 {% include footer.html %}
 

--- a/_layouts/sign_up_form.html
+++ b/_layouts/sign_up_form.html
@@ -1,0 +1,16 @@
+{% include head.html %}
+
+<div class="container">
+    {% include header.html %}
+
+<h1>Hack Brexit Mailing List</h1>
+
+<p>Sign up on our Hack Brexit contact form for us to keep you updated with all of the latest news </p>
+
+  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSftbQrHueHZpjbXyXhWKvR-uixs2J_BFhxJL29ZVp-v9vFoiQ/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+
+    {% endfor %}
+</div>
+{% include footer.html %}
+
+{% include foot.html %}

--- a/_layouts/sign_up_form.html
+++ b/_layouts/sign_up_form.html
@@ -7,12 +7,20 @@
 
 <p>Sign up on our Hack Brexit contact form for us to keep you updated with all of the latest news </p>
 
+<form method="POST" action="http://formspree.io/hackbrexit@gmail.com">
+  <input type="email" name="email" placeholder="Your email">
+  <input type="name" name="name" placeholder="Your name">
+  <button type="submit">Send</button>
+</form>
+
+{% comment %}
 <form accept-charset="UTF-8" action="https://docs.google.com/forms/d/e/1FAIpQLSftbQrHueHZpjbXyXhWKvR-uixs2J_BFhxJL29ZVp-v9vFoiQ/viewform" method="POST">
   <input type="email" name="email" placeholder="Your Email">
   <input type="text" name="name" placeholder="Your Name">
   <input type="hidden" name="utf8" value="✓">
   <button type="submit">Submit</button>
 </form>
+{% endcomment %}
 
 {% comment %}
 <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSftbQrHueHZpjbXyXhWKvR-uixs2J_BFhxJL29ZVp-v9vFoiQ/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>

--- a/_layouts/sign_up_form.html
+++ b/_layouts/sign_up_form.html
@@ -5,23 +5,21 @@
 
 <h1>Hack Brexit Mailing List</h1>
 
-<p>Fill in your details below for us to keep you updated with the latest news and developments about the Hack Brexit project.</p>
+<p>Fill in your details here for us to keep you updated with the latest news about the Hack Brexit project.</p>
 
-<form method="POST" action="http://formspree.io/hackbrexit@gmail.com">
-
-<form class="form-inline">
+<form method="POST" action="http://formspree.io/hackbrexit@gmail.com" class="form-inline">
   <div class="form-group">
-       <label for="exampleInputName2">Name</label>
-       <input type="name" name="name" class="form-control" id="exampleInputName2" placeholder="Your name">
+    <label for="exampleInputName2">Name</label>
+    <input type="name" name="name" class="form-control" id="exampleInputName2" placeholder="Your name">
+  </div>
+   
+   <div class="form-group">
+     <label for="exampleInputEmail2">Email</label>
+     <input type="email" email="email" class="form-control" id="exampleInputEmail2" placeholder="Your email">
+   </div>
 
- </div>
- <div class="form-group">
-   <label for="exampleInputEmail2">Email</label>
-   <input type="email" email="email" class="form-control" id="exampleInputEmail2" placeholder="Your email">
- </div>
  <button type="submit" class="btn btn-primary">Sign up for updates on Hack Brexit</button>
 </form>
-
 
 </div>
 {% include footer.html %}

--- a/_layouts/sign_up_form.html
+++ b/_layouts/sign_up_form.html
@@ -7,18 +7,18 @@
 
 <p>Fill in your details here for us to keep you updated with the latest news about the Hack Brexit project.</p>
 
-<form method="POST" action="http://formspree.io/hackbrexit@gmail.com" class="form-inline">
+<form method="post" action="http://formspree.io/hackbrexit@gmail.com">
   <div class="form-group">
-    <label for="exampleInputName2">Name</label>
-    <input type="name" name="name" class="form-control" id="exampleInputName2" placeholder="Your name">
+    <label for="fullname">Full Name</label>
+    <input type="name" name="name" class="form-control" id="fullname" placeholder="Your fullname">
   </div>
-   
+
    <div class="form-group">
-     <label for="exampleInputEmail2">Email</label>
-     <input type="email" email="email" class="form-control" id="exampleInputEmail2" placeholder="Your email">
+     <label for="email">Email</label>
+     <input type="email" email="email" class="form-control" id="email" placeholder="Your email">
    </div>
 
- <button type="submit" class="btn btn-primary">Sign up for updates on Hack Brexit</button>
+ <button type="submit" class="btn btn-primary btn-block">Sign up for updates on Hack Brexit</button>
 </form>
 
 </div>

--- a/sign_up_form.html
+++ b/sign_up_form.html
@@ -1,0 +1,3 @@
+---
+layout: default
+---

--- a/sign_up_form.html
+++ b/sign_up_form.html
@@ -1,3 +1,3 @@
 ---
-layout: default
+layout: Sign up form
 ---

--- a/sign_up_form.html
+++ b/sign_up_form.html
@@ -1,3 +1,3 @@
 ---
-layout: Sign up form
+layout: sign_up_form
 ---


### PR DESCRIPTION
Working on issue #18. Used existing default and gallery html files as template guides. Attempted to add in a sign_up_form.html to layouts folder &  sign_up_form.html to img folder. 

* [x] This feature remains incomplete, need to work out why the new sign up page created isn’t appearing. @eddiejaoude advice on Jekyll would be great!

# Tasks to be done:

1. [x] Create type form for sign up -created a google form: https://docs.google.com/forms/d/e/1FAIpQLSftbQrHueHZpjbXyXhWKvR-uixs2J_BFhxJL29ZVp-v9vFoiQ/viewform?embedded=true
2. [x] Create page for sign up form -see screen shot this now appears correctly
3. [x] Linked from main navigation - see screen shot this is now linked
3. [x] Embed form on new page  - replaced the google form with a [Formspree form](https://formspree.io). Users can now submit contact details which are then emailed to a Hack Brexit gmail account & then need to be stored by an administrator. 
4. [ ] Explore alternatives for sign up form so that data could be stored in a JSON file or a database so that data collection is more efficient, and doesn't depend on an Admin checking & collating emails from Formspree. 


![hack brexit sign up form created](https://cloud.githubusercontent.com/assets/16884984/20524169/73d5760c-b0b9-11e6-84e2-a97c3aa002d0.png)



